### PR TITLE
Fix Android crash (use 'each' instead of 'forEach')

### DIFF
--- a/block/src/me13/core/block/BlockConnections.java
+++ b/block/src/me13/core/block/BlockConnections.java
@@ -25,7 +25,7 @@ public class BlockConnections {
 
     public static Seq<Building> getConnections(Building source, ConnectionHand hand) {
         Seq<Building> seq = new Seq<>();
-        source.proximity.forEach(b -> {
+        source.proximity.each(b -> {
             if(hand.valid(source, b, b.tile)) {
                 seq.add(b);
             }

--- a/block/src/me13/core/block/instance/AdvancedBlock.java
+++ b/block/src/me13/core/block/instance/AdvancedBlock.java
@@ -34,7 +34,7 @@ public class AdvancedBlock extends Block {
             super.drawPlanRegion(plan, list);
         }
 
-        layers.forEach(layer -> {
+        layers.each(layer -> {
             if(layer != null) {
                 layer.drawPlan(plan, list);
             }
@@ -44,7 +44,7 @@ public class AdvancedBlock extends Block {
     @Override
     public void load() {
         super.load();
-        layers.forEach((layer) -> {
+        layers.each((layer) -> {
             if(layer != null) {
                 layer.load(this);
             }
@@ -75,7 +75,7 @@ public class AdvancedBlock extends Block {
                 super.draw();
             }
 
-            layers.forEach((layer) -> {
+            layers.each((layer) -> {
                 if(layer != null) {
                     layer.draw(this);
                 }


### PR DESCRIPTION
Android doesn't support the `forEach()` function, use instead the `each()` function.

Pull Request needed for: https://github.com/MindustryExtended13/MaterialEnergy/pull/4