### PR TITLE
Forbidden types

### DIFF
--- a/configuration/src/me13/core/configuration/Configuration.java
+++ b/configuration/src/me13/core/configuration/Configuration.java
@@ -1,18 +1,13 @@
 package me13.core.configuration;
 
 import arc.files.Fi;
-import java.util.HashMap;
-import java.util.Map;
+import arc.struct.ObjectMap;
 
 public class Configuration {
-    private final Map<String, String> defaults = new HashMap<>();
+    private final ObjectMap<String, String> defaults = new ObjectMap<>();
 
     public void setDefKey(String id, String def) {
-        if(defaults.containsKey(id)) {
-            defaults.replace(id, def);
-        } else {
-            defaults.put(id, def);
-        }
+        defaults.put(id, def);
     }
 
     public void setKey(String id, String content) {

--- a/util/src/me13/core/queue/Queue.java
+++ b/util/src/me13/core/queue/Queue.java
@@ -1,8 +1,8 @@
 package me13.core.queue;
 
+import arc.func.Cons;
 import arc.util.Log;
 import org.jetbrains.annotations.Contract;
-import java.util.function.Consumer;
 
 public class Queue<T> {
     public final T value;
@@ -12,15 +12,15 @@ public class Queue<T> {
         this.value = value;
     }
 
-    public void process(Consumer<T> handler) {
+    public void process(Cons<T> handler) {
         process(handler, Log::err);
     }
 
-    public void process(Consumer<T> handler, Consumer<Throwable> fail) {
+    public void process(Cons<T> handler, Cons<Throwable> fail) {
         try {
-            handler.accept(value);
+            handler.get(value);
         } catch(Throwable throwable) {
-            fail.accept(throwable);
+            fail.get(throwable);
         }
     }
 }


### PR DESCRIPTION
[Link](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md#do-not-use-incompatible-java-features-javautilfunction-javaawt)

Android and RoboVM (iOS) do not support many of Java 8's features, such as the packages java.util.function, java.util.stream or forEach in collections. Do not use these in your code.
If you need to use functional interfaces, use the ones in arc.func, which are more or less the same with different naming schemes.

The same applies to any class outside of the standard java.[n]io / java.net / java.util packages: Most of them are not supported.
java.awt is one of these packages: do not use it, ever. It is not supported on any platform, even desktop - the entire package is removed during JRE minimization. In general, if you are using IntelliJ, you should be warned about platform incompatiblities.